### PR TITLE
Add griffine requirement (to support COG notebook)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,6 +4,7 @@ earthaccess
 folium
 # eo_insights[notebooks] @ git+https://github.com/auspatious/eo-insights.git
 geopandas
+griffine
 ipyleaflet
 jinja2
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 #    uv pip compile --output-file=requirements.txt requirements.in
 affine==2.4.0
     # via
+    #   griffine
     #   odc-geo
     #   odc-stac
     #   rasterio
@@ -113,6 +114,8 @@ fsspec==2025.3.2
     #   earthaccess
     #   s3fs
 geopandas==1.0.1
+    # via -r requirements.in
+griffine==0.1.0
     # via -r requirements.in
 idna==3.10
     # via
@@ -264,6 +267,8 @@ pydantic==2.11.3
     # via planetary-computer
 pydantic-core==2.33.1
     # via pydantic
+pygeoif==1.5.1
+    # via griffine
 pygments==2.19.1
     # via
     #   ipython
@@ -392,6 +397,7 @@ typing-extensions==4.13.2
     #   pqdm
     #   pydantic
     #   pydantic-core
+    #   pygeoif
     #   python-cmr
     #   referencing
     #   typing-inspection


### PR DESCRIPTION
I ran through my COG notebook in the codespace and everything worked well. I cloned my repo quite easily at the terminal, opened the notebook and selected the kernel, then ran all the cells.

The only dependency missing was what I expected, `griffine`, the library I just published yesterday (it abstracts the grid operations in the notebook to remove a lot of the interesting-but-orthogonal math operations, with the hope this reduces the cognitive load).

It is easy enough to install it by running `pip install griffine` in the terminal, but if we wanted to avoid that _one step_ we could add it to the requirements. Hence this PR for consideration. I think it is easy enough just to install it, but it is obviously just a little easier to start with it installed, if polluting the requirements list isn't a concern. The only additional transitive dependency it pulls in is `pygeoif`, so it is pretty lightweight to include if desired.

Note that running `uv pip compile` removed a couple things from the `requirements.txt`:

```
diff --git a/requirements.txt b/requirements.txt
index 1083d63..59165ec 100644
--- a/requirements.txt
+++ b/requirements.txt
@@ -123,8 +123,6 @@ idna==3.10
     #   yarl
 imagecodecs==2025.3.30
     # via odc-geo
-importlib-metadata==8.6.1
-    # via dask
 importlib-resources==6.5.2
     # via earthaccess
 ipyleaflet==0.19.2
@@ -393,7 +391,6 @@ typing-extensions==4.13.2
     #   azure-core
     #   azure-storage-blob
     #   earthaccess
-    #   ipython
     #   pqdm
     #   pydantic
     #   pydantic-core
@@ -430,5 +427,3 @@ yarl==1.20.0
     # via aiohttp
 zict==3.0.0
     # via distributed
-zipp==3.21.0
-    # via importlib-metadata
```

I did not commit those removals because I wasn't sure why they happened.

Anyway, something to consider. Feel free to close without merging and I'll just have people do the pip install.